### PR TITLE
Make Initial 4.4.11 Changes to Standalone Module

### DIFF
--- a/terraform-k8s-codecov/minio.tf
+++ b/terraform-k8s-codecov/minio.tf
@@ -24,7 +24,7 @@ resource "kubernetes_deployment" "minio_storage" {
         }
         container {
           name  = "minio"
-          image = "minio/minio:RELEASE.2019-04-09T01-22-30Z"
+          image = "minio/minio:RELEASE.2019-10-02T21-19-38Z"
           args  = ["gateway", "nas", "/storage"]
           port {
             container_port = 9000

--- a/terraform-k8s-codecov/templates/codecov.yml.tpl
+++ b/terraform-k8s-codecov/templates/codecov.yml.tpl
@@ -36,3 +36,6 @@ services:
     hash_key: "ab164bf3f7d947f2a0681b215404873e" #do not edit
     access_key_id: ${minio_access_key}
     secret_access_key: ${minio_secret_key}
+    host: ${minio_host}
+    port: ${minio_port}
+    client_uploads: ${minio_client_uploads}

--- a/terraform-k8s-codecov/variables.tf
+++ b/terraform-k8s-codecov/variables.tf
@@ -68,7 +68,7 @@ variable "minio_secret_key" {
 }
 
 variable "minio_client_uploads" {
-  description = "Determines if uploads will used presigned PUTs (false) or direct upload (true)"
+  description = "Determines if uploads will use presigned PUTs (false) or direct upload (true)"
   default = "true"
 }
 

--- a/terraform-k8s-codecov/variables.tf
+++ b/terraform-k8s-codecov/variables.tf
@@ -66,3 +66,18 @@ variable "minio_secret_key" {
   description = "Secret key for minio"
   default = ""
 }
+
+variable "minio_client_uploads" {
+  description = "Determines if uploads will used presigned PUTs (false) or direct upload (true)"
+  default = "true"
+}
+
+variable "minio_host" {
+  description = "Host URL for minio server"
+  default = "minio"
+}
+
+variable "minio_port" {
+  description = "Host port for minio server"
+  default = "9000"
+}

--- a/terraform-k8s-codecov/web.tf
+++ b/terraform-k8s-codecov/web.tf
@@ -24,7 +24,7 @@ resource "kubernetes_deployment" "web" {
         }
         container {
           name  = "web"
-          image = "codecov/enterprise:v4.4.4"
+          image = "codecov/enterprise:v4.4.11"
           args  = ["web"]
           port {
             container_port = 5000
@@ -36,14 +36,6 @@ resource "kubernetes_deployment" "web" {
                 field_path = "status.hostIP"
               }
             }
-          }
-          env {
-            name = "MINIO_PORT_9000_TCP_ADDR"
-            value = "minio"
-          }
-          env {
-            name = "MINIO_PORT_9000_TCP_PORT"
-            value = "9000"
           }
           resources {
             limits {

--- a/terraform-k8s-codecov/worker.tf
+++ b/terraform-k8s-codecov/worker.tf
@@ -34,14 +34,6 @@ resource "kubernetes_deployment" "worker" {
               }
             }
           }
-          env {
-            name = "MINIO_PORT_9000_TCP_ADDR"
-            value = "minio"
-          }
-          env {
-            name = "MINIO_PORT_9000_TCP_PORT"
-            value = "9000"
-          }
           resources {
             limits {
               cpu    = "512m"


### PR DESCRIPTION
Updated CCE module to use v4.4.11. Also made relevant updates to web, worker, minio, and variables configuration to support minio direct uploads from web pods after upload. 