### PR TITLE
Update gcp stack feedback

### DIFF
--- a/google_kubernetes_engine/README.md
+++ b/google_kubernetes_engine/README.md
@@ -54,7 +54,7 @@ defined in a `terraform.tfvars` file.  More info on
 | `gcloud_project` | Google cloud project name | required |
 | `region` | Google cloud region | us-east4 |
 | `zone` | Default Google cloud zone for zone-specific services | us-east4a |
-| `codecov_version` | Version of codecov enterprise to deploy | 4.4.7 |
+| `codecov_version` | Version of codecov enterprise to deploy | 4.5.0 |
 | `cluster_name` | Google Kubernetes Engine (GKE) cluster name | default-codecov-cluster |
 | `web_node_pool_count` | Number of nodes to create in the web node pool | 1 |
 | `worker_node_pool_count` | Number of nodes to create in the worker node pool | 1 |
@@ -62,12 +62,11 @@ defined in a `terraform.tfvars` file.  More info on
 | `web_resources` | Map of resources for web k8s deployment | See `variables.tf` |
 | `worker_resources` | Map of resources for worker k8s deployment | See `variables.tf` |
 | `traefik_resources` | Map of resources for traefik k8s deployment | See `variables.tf` |
+| `enable_traefik` | Whether to include Traefik for ingress and HTTPS | 1 |
 | `minio_bucket_name` | Name of GCS bucket to create for minio | required |
 | `minio_bucket_location` | Name of GCS bucket to create for minio | US |
 | `minio_bucket_force_destroy` | Required to allow destroying a non-empty bucket | false |
-| `redis_instance_name` | Name used for redis instance | required |
 | `redis_memory_size` | Amount of memory in GB to allocate for redis instance | 5 |
-| `postgres_instance_name` | Name used for postgres instance | required |
 | `postgres_instance_type` | Instance type used for postgres | db-f1-micro |
 | `codecov_yml` | Path to your codecov.yml | required |
 | `ingress_host` | Hostname used for http(s) ingress. (ex: `codecov.yourdomain.com`) | |
@@ -82,6 +81,23 @@ defined in a `terraform.tfvars` file.  More info on
 If `scm_ca_cert` is configured, it will be available to Codecov at
 `/cert/scm_ca_cert.pem`.  Include this path in your `codecov.yml` in the scm
 config.
+
+### Instance Types
+
+The default instance types and number of instances are the minimum to get
+the Codecov application up and running.  Tuning these will be required,
+dependent on your specific use-case.
+
+### Traefik
+
+Traefik is included for ingress in order to support HTTPS, streamline the setup, 
+and make this stack as turn-key as possible.  It can be excluded in favor of 
+using GCP services to manage your domain and certificate.  To disable Traefik,
+include this in your `terraform.tfvars` file:
+
+```
+enable_traefik = 0
+```
 
 ## Executing terraform
 

--- a/google_kubernetes_engine/README.md
+++ b/google_kubernetes_engine/README.md
@@ -42,7 +42,7 @@ account.
 
 Configuration of Codecov enterprise is handled through a YAML config file.
 See [configuring codecov.yml](https://docs.codecov.io/docs/configuration) for 
-more info.  Refer to this example [codecov.yml](../codecov.yml.example) for the
+more info.  Refer to this example [codecov.yml](codecov.yml.example) for the
 minimum necessary configuration.
 
 The terraform stack is configured using terraform variables which can be

--- a/google_kubernetes_engine/README.md
+++ b/google_kubernetes_engine/README.md
@@ -84,7 +84,7 @@ config.
 
 ### Instance Types
 
-The default instance types and number of instances are the minimum to get
+The default node pool machine type and number of instances are the minimum to get
 the Codecov application up and running.  Tuning these will be required,
 dependent on your specific use-case.
 
@@ -98,6 +98,13 @@ include this in your `terraform.tfvars` file:
 ```
 enable_traefik = 0
 ```
+
+### Granting Codecov access to internal resources
+
+If your organization requires creating firewall rules to grant Codecov access
+to your internal resources, the IP address for the NAT gateway can be found in
+the terraform output.  All requests from Codecov Enterprise will originate from
+this address.
 
 ## Executing terraform
 

--- a/google_kubernetes_engine/cluster.tf
+++ b/google_kubernetes_engine/cluster.tf
@@ -20,6 +20,14 @@ resource "google_container_cluster" "primary" {
   ip_allocation_policy {
   }
 
+  network = google_compute_network.codecov.name
+
+  private_cluster_config {
+    enable_private_nodes = "true"
+    enable_private_endpoint = "false"
+    master_ipv4_cidr_block = "10.254.0.0/28"
+  }
+
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default
   # node pool and immediately delete it.

--- a/google_kubernetes_engine/codecov.yml.example
+++ b/google_kubernetes_engine/codecov.yml.example
@@ -1,0 +1,11 @@
+setup:
+  codecov_url: https://codecov.yourdomain.com
+  enterprise_license: "Codecov-Enterprise-License-Key"
+  http:
+    cookie_secret: "cookie-secret"
+github:
+  client_id: "example-client-id"
+  client_secret: "example-client-secret"
+
+#gitlab_enterprise:
+#  ssl_pem: /cert/scm_ca_cert.pem

--- a/google_kubernetes_engine/databases.tf
+++ b/google_kubernetes_engine/databases.tf
@@ -1,5 +1,5 @@
 resource "google_redis_instance" "codecov" {
-  name           = var.redis_instance_name
+  name           = "codecov-enterprise-${random_pet.databases.id}"
   memory_size_gb = var.redis_memory_size
 
   labels = var.resource_tags
@@ -9,13 +9,13 @@ resource "google_redis_instance" "codecov" {
 # consistent.  For tasks that require recreation of the db resource, using the 
 # same name often fails because it remains reserved until the record of the db
 # instance is fully purged from google's metadata.
-resource "random_pet" "postgres" {
+resource "random_pet" "databases" {
   length    = "2"
   separator = "-"
 }
 
 resource "google_sql_database_instance" "codecov" {
-  name             = "${var.postgres_instance_name}-${random_pet.postgres.id}"
+  name             = "codecov-enterprise-${random_pet.databases.id}"
   database_version = "POSTGRES_9_6"
   region           = var.region
 

--- a/google_kubernetes_engine/nat.tf
+++ b/google_kubernetes_engine/nat.tf
@@ -1,0 +1,35 @@
+resource "google_compute_network" "codecov" {
+  name = "codecov-enterprise"
+}
+
+resource "google_compute_address" "nat" {
+  name = "codecov-enterprise"
+}
+
+output "egress-ip" {
+  value = google_compute_address.nat.address
+}
+
+resource "google_compute_router" "codecov" {
+  name    = "codecov-enterprise"
+  region  = var.region
+  network = google_compute_network.codecov.name
+}
+
+
+resource "google_compute_router_nat" "nat" {
+  name                               = "codecov-nat"
+  router                             = google_compute_router.codecov.name
+  region                             = var.region
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  nat_ips = [
+    google_compute_address.nat.self_link
+  ]
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}

--- a/google_kubernetes_engine/traefik.tf
+++ b/google_kubernetes_engine/traefik.tf
@@ -29,6 +29,7 @@ EOF
 }
 
 resource "kubernetes_config_map" "traefik-toml" {
+  count = var.enable_traefik
   metadata {
     name = "traefik-config"
     annotations = var.resource_tags
@@ -45,6 +46,7 @@ resource "kubernetes_config_map" "traefik-toml" {
 }
 
 resource "kubernetes_secret" "traefik-tls" {
+  count = var.enable_traefik
   metadata {
     name = "traefik-tls"
     annotations = var.resource_tags
@@ -57,6 +59,7 @@ resource "kubernetes_secret" "traefik-tls" {
 }
 
 resource "kubernetes_deployment" "traefik" {
+  count = var.enable_traefik
   metadata {
     name = "traefik"
     annotations = var.resource_tags
@@ -166,6 +169,7 @@ resource "kubernetes_deployment" "traefik" {
 }
 
 resource "kubernetes_service" "traefik" {
+  count = var.enable_traefik
   metadata {
     name = "traefik"
     annotations = var.resource_tags
@@ -183,12 +187,6 @@ resource "kubernetes_service" "traefik" {
       port        = "443"
       target_port = "443"
     }
-    port {
-      name        = "admin"
-      protocol    = "TCP"
-      port        = "8080"
-      target_port = "8080"
-    }
     selector = {
       app = "traefik"
     }
@@ -197,6 +195,7 @@ resource "kubernetes_service" "traefik" {
 }
 
 resource "kubernetes_ingress" "traefik" {
+  count = var.enable_traefik
   metadata {
     name = "traefik"
     annotations = merge({
@@ -222,6 +221,5 @@ resource "kubernetes_ingress" "traefik" {
 }
 
 output "ingress-ip" {
-  value = kubernetes_service.traefik.load_balancer_ingress[0].ip
+  value = length(kubernetes_service.traefik) > 0 ? kubernetes_service.traefik[0].load_balancer_ingress[0].ip : null
 }
-

--- a/google_kubernetes_engine/variables.tf
+++ b/google_kubernetes_engine/variables.tf
@@ -14,7 +14,7 @@ variable "zone" {
 
 variable "codecov_version" {
   description = "Version of codecov enterprise to deploy"
-  default     = "4.4.12"
+  default     = "4.5.0"
 }
 
 variable "cluster_name" {
@@ -70,6 +70,11 @@ variable "traefik_resources" {
   }
 }
 
+variable "enable_traefik" {
+  description = "Whether or not to include Traefik ingress"
+  default     = "1"
+}
+
 variable "minio_bucket_name" {
   description = "Name of GCS bucket to create for minio"
 }
@@ -84,17 +89,9 @@ variable "minio_bucket_force_destroy" {
   default     = "false"
 }
 
-variable "redis_instance_name" {
-  description = "Name used for redis instance"
-}
-
 variable "redis_memory_size" {
   description = "Memory size in GB for redis instance"
   default     = "5"
-}
-
-variable "postgres_instance_name" {
-  description = "Name used for postgres instance"
 }
 
 variable "postgres_instance_type" {

--- a/google_kubernetes_engine/web.tf
+++ b/google_kubernetes_engine/web.tf
@@ -68,6 +68,10 @@ resource "kubernetes_deployment" "web" {
             }
           }
           env {
+            name = "STATSD_PORT"
+            value = "8125"
+          }
+          env {
             name  = "SERVICES__DATABASE_URL"
             value = "postgres://${google_sql_user.codecov.name}:${google_sql_user.codecov.password}@127.0.0.1:5432/${google_sql_database.codecov.name}"
           }

--- a/google_kubernetes_engine/worker.tf
+++ b/google_kubernetes_engine/worker.tf
@@ -45,6 +45,10 @@ resource "kubernetes_deployment" "worker" {
             }
           }
           env {
+            name = "STATSD_PORT"
+            value = "8125"
+          }
+          env {
             name  = "SERVICES__DATABASE_URL"
             value = "postgres://${google_sql_user.codecov.name}:${google_sql_user.codecov.password}@127.0.0.1:5432/${google_sql_database.codecov.name}"
           }


### PR DESCRIPTION
- Bump default codecov version to 4.5
- Add notes on cluster node type, traefik, and egress ip
- Set up nat gateway with static egress ip
- Add codecov.yml.example
- Make traefik optional
- Remove vars for db/redis names
- Add statsd port env var
