### PR TITLE
Update azure stack based on feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ codecov.yml
 kubeconfig_default-codecov-cluster
 config-map-aws-auth_default-codecov-cluster.yaml
 *.log
+ssh_key.pub

--- a/azure_kubernetes_service/README.md
+++ b/azure_kubernetes_service/README.md
@@ -48,7 +48,7 @@ for a fully robust deployment.
 
 Configuration of Codecov enterprise is handled through a YAML config file.
 See [configuring codecov.yml](https://docs.codecov.io/docs/configuration) for 
-more info.  Refer to this example [codecov.yml](../codecov.yml.example) for the
+more info.  Refer to this example [codecov.yml](codecov.yml.example) for the
 minimum necessary configuration.
 
 The terraform stack is configured using terraform variables which can be
@@ -70,6 +70,7 @@ defined in a `terraform.tfvars` file.  More info on
 | `worker_resources` | Map of resources for worker k8s deployment | See `variables.tf` |
 | `minio_resources` | Map of resources for minio k8s deployment | See `variables.tf` |
 | `traefik_resources` | Map of resources for traefik k8s deployment | See `variables.tf` |
+| `enable_traefik` | Whether to include Traefik for ingress and HTTPS | 1 |
 | `codecov_yml` | Path to your codecov.yml | codecov.yml |
 | `ingress_host` | Hostname used for http(s) ingress | |
 | `enable_https` | Enables https ingress.  Requires TLS cert and key | 0 |
@@ -84,6 +85,30 @@ defined in a `terraform.tfvars` file.  More info on
 If `scm_ca_cert` is configured, it will be available to Codecov at
 `/cert/scm_ca_cert.pem`.  Include this path in your `codecov.yml` in the scm
 config.
+
+### Instance Types
+
+The default node pool VM size and number of instances are the minimum to get
+the Codecov application up and running.  Tuning these will be required,
+dependent on your specific use-case.
+
+### Traefik
+
+Traefik is included for ingress in order to support HTTPS, streamline the setup, 
+and make this stack as turn-key as possible.  It can be excluded in favor of 
+using GCP services to manage your domain and certificate.  To disable Traefik,
+include this in your `terraform.tfvars` file:
+
+```
+enable_traefik = 0
+```
+
+### Granting Codecov access to internal resources
+
+If your organization requires creating firewall rules to grant Codecov access
+to your internal resources, the IP address for the NAT gateway can be found in
+the terraform output as `egress-ip`.  All requests from Codecov Enterprise 
+will originate from this address.
 
 ## Executing terraform
 

--- a/azure_kubernetes_service/codecov.yml.example
+++ b/azure_kubernetes_service/codecov.yml.example
@@ -1,0 +1,11 @@
+setup:
+  codecov_url: https://codecov.yourdomain.com
+  enterprise_license: "Codecov-Enterprise-License-Key"
+  http:
+    cookie_secret: "cookie-secret"
+github:
+  client_id: "example-client-id"
+  client_secret: "example-client-secret"
+
+#gitlab_enterprise:
+#  ssl_pem: /cert/scm_ca_cert.pem

--- a/azure_kubernetes_service/databases.tf
+++ b/azure_kubernetes_service/databases.tf
@@ -13,16 +13,14 @@ resource "azurerm_postgresql_server" "codecov" {
 
   sku_name = var.postgres_sku
 
-  storage_profile {
-    storage_mb            = var.postgres_storage_profile["storage_mb"]
-    backup_retention_days = var.postgres_storage_profile["backup_retention_days"]
-    geo_redundant_backup  = var.postgres_storage_profile["geo_redundant_backup"]
-  }
+  storage_mb                   = var.postgres_storage_profile["storage_mb"]
+  backup_retention_days        = var.postgres_storage_profile["backup_retention_days"]
+  geo_redundant_backup_enabled = var.postgres_storage_profile["geo_redundant_backup_enabled"]
 
   administrator_login          = "codecov"
   administrator_login_password = random_password.postgres-password.result
   version                      = "9.6"
-  ssl_enforcement              = "Disabled"
+  ssl_enforcement_enabled      = "false"
 
   tags = var.resource_tags
 }

--- a/azure_kubernetes_service/providers.tf
+++ b/azure_kubernetes_service/providers.tf
@@ -5,7 +5,7 @@ terraform {
 # provider block and features block are now required
 # https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/CHANGELOG.md#200-february-24-2020
 provider "azurerm" {
-  version = "~>2.4"
+  version = "~>2.17"
   features {} 
 }
 

--- a/azure_kubernetes_service/service_accounts.tf
+++ b/azure_kubernetes_service/service_accounts.tf
@@ -1,0 +1,57 @@
+resource "kubernetes_service_account" "traefik" {
+  metadata {
+    name      = "codecov-traefik"
+    namespace = "default"
+  }
+}
+
+resource "kubernetes_cluster_role" "traefik" {
+  metadata {
+    name      = "codecov-traefik"
+  }
+
+  rule {
+    api_groups = [""]
+    resources = [
+      "services",
+      "endpoints",
+      "secrets",
+    ]
+    verbs = [
+      "get",
+      "list",
+      "watch",
+    ]
+  }
+
+  rule {
+    api_groups = [
+      "extensions",
+    ]
+    resources = [
+      "ingresses",
+    ]
+    verbs = [
+      "get",
+      "list",
+      "watch",
+    ]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "traefik" {
+  metadata {
+    name = "codecov-traefik"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.traefik.metadata[0].name
+    namespace = kubernetes_service_account.traefik.metadata[0].namespace
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.traefik.metadata[0].name
+  }
+}
+

--- a/azure_kubernetes_service/variables.tf
+++ b/azure_kubernetes_service/variables.tf
@@ -59,7 +59,7 @@ variable "web_resources" {
 variable "worker_resources" {
   type = map
   default = {
-    replicas = 4
+    replicas = 3
     cpu_limit = "512m"
     memory_limit = "2048M"
     cpu_request = "256m"
@@ -87,6 +87,11 @@ variable "traefik_resources" {
     cpu_request = "32m"
     memory_request = "64M"
   }
+}
+
+variable "enable_traefik" {
+  description = "Whether or not to include Traefik ingress"
+  default     = "1"
 }
 
 variable "codecov_yml" {

--- a/azure_kubernetes_service/variables.tf
+++ b/azure_kubernetes_service/variables.tf
@@ -39,9 +39,9 @@ variable "postgres_sku" {
 variable "postgres_storage_profile" {
   description = "Storage profile for PostgreSQL DB"
   default = {
-    storage_mb            = "5120"
-    backup_retention_days = "7"
-    geo_redundant_backup  = "Disabled"
+    storage_mb                   = "5120"
+    backup_retention_days        = "7"
+    geo_redundant_backup_enabled = "false"
   }
 }
 

--- a/azure_kubernetes_service/virtual_network.tf
+++ b/azure_kubernetes_service/virtual_network.tf
@@ -10,7 +10,9 @@ resource "azurerm_subnet" "codecov" {
   name                 = "codecov"
   virtual_network_name = azurerm_virtual_network.codecov.name
   resource_group_name  = azurerm_resource_group.codecov-enterprise.name
-  address_prefix       = "10.1.8.0/21"
+  address_prefixes     = [
+    "10.1.8.0/21"
+  ]
   service_endpoints = [
     "Microsoft.Sql",
     "Microsoft.Storage",

--- a/azure_kubernetes_service/web.tf
+++ b/azure_kubernetes_service/web.tf
@@ -45,6 +45,10 @@ resource "kubernetes_deployment" "web" {
             }
           }
           env {
+            name = "STATSD_PORT"
+            value = "8125"
+          }
+          env {
             name  = "DATABASE_USERNAME"
             value = local.postgres_username
           }

--- a/azure_kubernetes_service/worker.tf
+++ b/azure_kubernetes_service/worker.tf
@@ -42,6 +42,10 @@ resource "kubernetes_deployment" "worker" {
             }
           }
           env {
+            name = "STATSD_PORT"
+            value = "8125"
+          }
+          env {
             name  = "DATABASE_USERNAME"
             value = local.postgres_username
           }


### PR DESCRIPTION
- Add notes on instance types/sizes
- Provide method to disable traefik if desired
- Provide static egress IP for firewall-based access to customer internal resources
- Provide example `codecov.yml` in azure subdirectory
- Bump azure provider constraint to latest version
- Restrict traefik service account permissions to minimum necessary
- Add static statsd port env var
