### PR TITLE
Version bump to 4.5.5 and fix tf module codecov.yml loading

### DIFF
--- a/aws_eks_migration/README.md
+++ b/aws_eks_migration/README.md
@@ -65,7 +65,7 @@ defined in a `terraform.tfvars` file.  More info on
 | `region` | AWS region | us-east-1 |
 | `vpc_id` | ID of VPC containing your PostgreSQL instance. This VPC will be used for EKS | |
 | `vpc_private_subnet_ids` | List of private subnet IDs to use for EKS nodes | `[]` |
-| `codecov_version` | Version of codecov enterprise to deploy | 4.4.7 |
+| `codecov_version` | Version of codecov enterprise to deploy | 4.5.5 |
 | `cluster_name` | Google Kubernetes Engine (GKE) cluster name | default-codecov-cluster |
 | `postgres_url` | URL for your postgres instance | |
 | `s3_bucket` | S3 bucket name used for report storage | |

--- a/aws_eks_migration/variables.tf
+++ b/aws_eks_migration/variables.tf
@@ -1,6 +1,6 @@
 variable "region" {
   description = "AWS region"
-  default = "us-east-1"
+  default     = "us-east-1"
 }
 
 variable "vpc_id" {
@@ -9,18 +9,18 @@ variable "vpc_id" {
 
 variable "vpc_private_subnet_ids" {
   description = "List of private subnet IDs to use for EKS nodes"
-  type = "list"
+  type        = "list"
   # example = ["subnet-abcd1234","subnet-efgh5678"]
 }
 
 variable "codecov_version" {
   description = "Version of codecov enterprise to deploy"
-  default = "4.4.7"
+  default     = "4.5.5"
 }
 
 variable "cluster_name" {
   description = "Google Kubernetes Engine (GKE) cluster name"
-  default = "default-codecov-cluster"
+  default     = "default-codecov-cluster"
 }
 
 variable "postgres_url" {
@@ -33,62 +33,62 @@ variable "s3_bucket" {
 
 variable "redis_node_type" {
   description = "Node type to use for redis cluster nodes"
-  default = "cache.t2.micro"
+  default     = "cache.t2.micro"
 }
 
 variable "redis_num_nodes" {
   description = "Number of nodes to run in the redis cluster"
-  default = "1"
+  default     = "1"
 }
 
 variable "web_nodes" {
   description = "Number of web nodes to create"
-  default = "2"
+  default     = "2"
 }
 
 variable "web_node_type" {
   description = "Instance type to use for web nodes"
-  default = "t2.medium"
+  default     = "t2.medium"
 }
 
 variable "worker_nodes" {
   description = "Number of worker nodes to create"
-  default = "2"
+  default     = "2"
 }
 
 variable "worker_node_type" {
   description = "Instance type to use for worker nodes"
-  default = "t2.medium"
+  default     = "t2.medium"
 }
 
 variable "minio_nodes" {
   description = "Number of minio nodes to create"
-  default = "2"
+  default     = "2"
 }
 
 variable "minio_node_type" {
   description = "Instance type to use for minio nodes"
-  default = "t2.medium"
+  default     = "t2.medium"
 }
 
 variable "web_replicas" {
   description = "Number of web replicas to execute"
-  default = "2"
+  default     = "2"
 }
 
 variable "worker_replicas" {
   description = "Number of worker replicas to execute"
-  default = "2"
+  default     = "2"
 }
 
 variable "minio_replicas" {
   description = "Number of minio replicas to execute"
-  default = "4"
+  default     = "4"
 }
 
 variable "codecov_yml" {
   description = "Path to your codecov.yml"
-  default = "codecov.yml"
+  default     = "codecov.yml"
 }
 
 variable "ingress_host" {
@@ -97,20 +97,20 @@ variable "ingress_host" {
 
 variable "traefik_replicas" {
   description = "Number of traefik replicas to deploy"
-  default = "2"
+  default     = "2"
 }
 
 variable "enable_https" {
   description = "Enables https ingress.  Requires TLS cert and key"
-  default = "0"
+  default     = "0"
 }
 
 variable "tls_key" {
   description = "Path to private key to use for TLS"
-  default = ""
+  default     = ""
 }
 
 variable "tls_cert" {
   description = "Path to certificate to use for TLS"
-  default = ""
+  default     = ""
 }

--- a/aws_elastic_kubernetes_service/README.md
+++ b/aws_elastic_kubernetes_service/README.md
@@ -60,7 +60,7 @@ defined in a `terraform.tfvars` file.  More info on
 | name | description | default |
 | --- | --- | --- |
 | `region` | AWS region | us-east-1 |
-| `codecov_version` | Version of codecov enterprise to deploy | 4.5.0 |
+| `codecov_version` | Version of codecov enterprise to deploy | 4.5.5 |
 | `cluster_name` | Google Kubernetes Engine (GKE) cluster name | default-codecov-cluster |
 | `postgres_instance_class` | Instance class for PostgreSQL RDS instance | db.t3.medium |
 | `postgres_skip_final_snapshot` | Whether to skip taking a final snapshot when destroying the Postgres DB. It is recommended to keep this set to 0 in production in order to avoid unintended data loss. | 0 |

--- a/aws_elastic_kubernetes_service/variables.tf
+++ b/aws_elastic_kubernetes_service/variables.tf
@@ -5,7 +5,7 @@ variable "region" {
 
 variable "codecov_version" {
   description = "Version of codecov enterprise to deploy"
-  default     = "4.5.0"
+  default     = "4.5.5"
 }
 
 variable "cluster_name" {
@@ -19,7 +19,7 @@ variable "postgres_instance_class" {
 }
 
 variable "postgres_skip_final_snapshot" {
-  type = bool
+  type        = bool
   description = "Whether to skip taking a final snapshot when destroying the Postgres DB"
   default     = "true"
 }
@@ -57,10 +57,10 @@ variable "worker_node_type" {
 variable "web_resources" {
   type = map
   default = {
-    replicas = 2
-    cpu_limit = "256m"
-    memory_limit = "512M"
-    cpu_request = "32m"
+    replicas       = 2
+    cpu_limit      = "256m"
+    memory_limit   = "512M"
+    cpu_request    = "32m"
     memory_request = "64M"
   }
 }
@@ -68,10 +68,10 @@ variable "web_resources" {
 variable "worker_resources" {
   type = map
   default = {
-    replicas = 4
-    cpu_limit = "512m"
-    memory_limit = "2048M"
-    cpu_request = "256m"
+    replicas       = 4
+    cpu_limit      = "512m"
+    memory_limit   = "2048M"
+    cpu_request    = "256m"
     memory_request = "2048M"
   }
 }
@@ -79,10 +79,10 @@ variable "worker_resources" {
 variable "traefik_resources" {
   type = map
   default = {
-    replicas = 2
-    cpu_limit = "256m"
-    memory_limit = "512M"
-    cpu_request = "32m"
+    replicas       = 2
+    cpu_limit      = "256m"
+    memory_limit   = "512M"
+    cpu_request    = "32m"
     memory_request = "64M"
   }
 }
@@ -126,5 +126,5 @@ variable "resource_tags" {
 
 variable "scm_ca_cert" {
   description = "SCM CA certificate path"
-  default = ""
+  default     = ""
 }

--- a/azure_kubernetes_service/README.md
+++ b/azure_kubernetes_service/README.md
@@ -60,7 +60,7 @@ defined in a `terraform.tfvars` file.  More info on
 | `location` | Azure location | eastus |
 | `azurerm_client_id` | `appId` from the SP creation output | |
 | `azurerm_client_secret` | `password` from the SP creation output | |
-| `codecov_version` | Version of codecov enterprise to deploy | 4.4.12 |
+| `codecov_version` | Version of codecov enterprise to deploy | 4.5.5 |
 | `cluster_name` | Azure Kubernetes Service (AKS) cluster name | default-codecov-cluster |
 | `node_pool_count` | Number of nodes to configure in the node pool | 5 |
 | `node_pool_vm_size` | VM size to use for node pool nodes | Standard_B2s |

--- a/azure_kubernetes_service/variables.tf
+++ b/azure_kubernetes_service/variables.tf
@@ -13,7 +13,7 @@ variable "azurerm_client_secret" {
 
 variable "codecov_version" {
   description = "Version of codecov enterprise to deploy"
-  default     = "4.4.12"
+  default     = "4.5.5"
 }
 
 variable "cluster_name" {
@@ -48,10 +48,10 @@ variable "postgres_storage_profile" {
 variable "web_resources" {
   type = map
   default = {
-    replicas = 2
-    cpu_limit = "256m"
-    memory_limit = "512M"
-    cpu_request = "32m"
+    replicas       = 2
+    cpu_limit      = "256m"
+    memory_limit   = "512M"
+    cpu_request    = "32m"
     memory_request = "64M"
   }
 }
@@ -59,10 +59,10 @@ variable "web_resources" {
 variable "worker_resources" {
   type = map
   default = {
-    replicas = 3
-    cpu_limit = "512m"
-    memory_limit = "2048M"
-    cpu_request = "256m"
+    replicas       = 3
+    cpu_limit      = "512m"
+    memory_limit   = "2048M"
+    cpu_request    = "256m"
     memory_request = "2048M"
   }
 }
@@ -70,10 +70,10 @@ variable "worker_resources" {
 variable "minio_resources" {
   type = map
   default = {
-    replicas = 2
-    cpu_limit = "256m"
-    memory_limit = "512M"
-    cpu_request = "32m"
+    replicas       = 2
+    cpu_limit      = "256m"
+    memory_limit   = "512M"
+    cpu_request    = "32m"
     memory_request = "64M"
   }
 }
@@ -81,10 +81,10 @@ variable "minio_resources" {
 variable "traefik_resources" {
   type = map
   default = {
-    replicas = 2
-    cpu_limit = "256m"
-    memory_limit = "512M"
-    cpu_request = "32m"
+    replicas       = 2
+    cpu_limit      = "256m"
+    memory_limit   = "512M"
+    cpu_request    = "32m"
     memory_request = "64M"
   }
 }
@@ -133,5 +133,5 @@ variable "resource_tags" {
 # 
 variable "scm_ca_cert" {
   description = "SCM CA certificate path"
-  default = ""
+  default     = ""
 }

--- a/google_kubernetes_engine/README.md
+++ b/google_kubernetes_engine/README.md
@@ -54,7 +54,7 @@ defined in a `terraform.tfvars` file.  More info on
 | `gcloud_project` | Google cloud project name | required |
 | `region` | Google cloud region | us-east4 |
 | `zone` | Default Google cloud zone for zone-specific services | us-east4a |
-| `codecov_version` | Version of codecov enterprise to deploy | 4.5.0 |
+| `codecov_version` | Version of codecov enterprise to deploy | 4.5.5 |
 | `cluster_name` | Google Kubernetes Engine (GKE) cluster name | default-codecov-cluster |
 | `web_node_pool_count` | Number of nodes to create in the web node pool | 1 |
 | `worker_node_pool_count` | Number of nodes to create in the worker node pool | 1 |

--- a/google_kubernetes_engine/variables.tf
+++ b/google_kubernetes_engine/variables.tf
@@ -14,7 +14,7 @@ variable "zone" {
 
 variable "codecov_version" {
   description = "Version of codecov enterprise to deploy"
-  default     = "4.5.0"
+  default     = "4.5.5"
 }
 
 variable "cluster_name" {
@@ -40,10 +40,10 @@ variable "node_pool_machine_type" {
 variable "web_resources" {
   type = map
   default = {
-    replicas = 2
-    cpu_limit = "256m"
-    memory_limit = "512M"
-    cpu_request = "32m"
+    replicas       = 2
+    cpu_limit      = "256m"
+    memory_limit   = "512M"
+    cpu_request    = "32m"
     memory_request = "64M"
   }
 }
@@ -51,10 +51,10 @@ variable "web_resources" {
 variable "worker_resources" {
   type = map
   default = {
-    replicas = 3
-    cpu_limit = "512m"
-    memory_limit = "1024M"
-    cpu_request = "256m"
+    replicas       = 3
+    cpu_limit      = "512m"
+    memory_limit   = "1024M"
+    cpu_request    = "256m"
     memory_request = "512M"
   }
 }
@@ -62,10 +62,10 @@ variable "worker_resources" {
 variable "traefik_resources" {
   type = map
   default = {
-    replicas = 2
-    cpu_limit = "256m"
-    memory_limit = "512M"
-    cpu_request = "32m"
+    replicas       = 2
+    cpu_limit      = "256m"
+    memory_limit   = "512M"
+    cpu_request    = "32m"
     memory_request = "64M"
   }
 }
@@ -138,5 +138,5 @@ variable "resource_tags" {
 
 variable "scm_ca_cert" {
   description = "SCM CA certificate path"
-  default = ""
+  default     = ""
 }

--- a/terraform-k8s-codecov/README.md
+++ b/terraform-k8s-codecov/README.md
@@ -34,10 +34,10 @@ arise as a result of their use.
 
 | name | description | default |
 | --- | --- | --- |
-| `codecov_version` | version of Codecov Enterprise to deploy | 4.5.0 |
-| `web_replicas` | number of web pod replicas to run | 2 |
-| `worker_replicas` | number of worker pod replicas to run | 2 |
-| `codecov_yml` | path to your enterprise [codecov.yml](https://docs.codecov.io/docs/configuration). [example](codecov.yml.example) | required |
+| `codecov_version` | Version of Codecov Enterprise to deploy | 4.5.5 |
+| `web_replicas` | Number of web pod replicas to run | 2 |
+| `worker_replicas` | Number of worker pod replicas to run | 2 |
+| `codecov_yml` | Path to your enterprise [codecov.yml](https://docs.codecov.io/docs/configuration). [example](codecov.yml.example) | required |
 | `resource_tags` | Map of tags to include in compatible resources | `{application=codecov, environment=test}` |
 | `scm_ca_cert` | Optional SCM CA certificate path in PEM format | |
 
@@ -55,10 +55,10 @@ config.
     # example module definition
     module "codecov" {
       source = "git@github.com:codecov/enterprise-resources.git//terraform-k8s-codecov"
-      codecov_version = "4.5.0"
+      codecov_version = "4.5.5"
       web_replicas = "2"
       worker_replicas = "2"
-      codecov_yml = file("${path.module}/codecov.yml")
+      codecov_yml = "${path.module}/codecov.yml"
       resource_tags = {
         application = "codecov",
         environment = "test",

--- a/terraform-k8s-codecov/secrets.tf
+++ b/terraform-k8s-codecov/secrets.tf
@@ -1,16 +1,16 @@
 resource "kubernetes_secret" "codecov-yml" {
   metadata {
-    name = "codecov-yml"
+    name        = "codecov-yml"
     annotations = var.resource_tags
   }
   data = {
-    "codecov.yml" = var.codecov_yml
+    "codecov.yml" = file(var.codecov_yml)
   }
 }
 
 resource "kubernetes_secret" "scm-ca-cert" {
   metadata {
-    name = "scm-ca-cert"
+    name        = "scm-ca-cert"
     annotations = var.resource_tags
   }
   data = {

--- a/terraform-k8s-codecov/variables.tf
+++ b/terraform-k8s-codecov/variables.tf
@@ -1,6 +1,6 @@
 variable "codecov_version" {
   description = "Version of Codecov Enterprise to deploy"
-  default = "4.5.0"
+  default     = "4.5.5"
 }
 
 variable "web_replicas" {
@@ -28,5 +28,5 @@ variable "resource_tags" {
 # 
 variable "scm_ca_cert" {
   description = "SCM CA certificate path"
-  default = ""
+  default     = ""
 }


### PR DESCRIPTION
- Updates default codecov enterprise version to 4.5.5
- Fixes terraform-k8s-codecov module to correctly load codecov.yml from a path as indicated in the readme