### PR TITLE
Add the ability to customize deployment annotations

### DIFF
--- a/helm/codecov-enterprise/templates/web-deployment.yaml
+++ b/helm/codecov-enterprise/templates/web-deployment.yaml
@@ -20,6 +20,10 @@ spec:
     metadata:
       labels:
         app: web
+      annotations:
+      {{- range $key, $value := .Values.web.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     spec:
       containers:
       - args:

--- a/helm/codecov-enterprise/templates/worker-deployment.yaml
+++ b/helm/codecov-enterprise/templates/worker-deployment.yaml
@@ -20,6 +20,10 @@ spec:
     metadata:
       labels:
         app: worker
+      annotations:
+      {{- range $key, $value := .Values.worker.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     spec:
       containers:
       - args:

--- a/helm/codecov-enterprise/values.yaml
+++ b/helm/codecov-enterprise/values.yaml
@@ -3,6 +3,7 @@ codecovVersion: 4.5.5
 # web deployment resources
 web:
   replicas: 2
+  annotations: {}
   resources:
     limits:
       cpu: 512m
@@ -14,6 +15,7 @@ web:
 # worker deployment resources
 worker:
   replicas: 2
+  annotations: {}
   resources:
     limits:
       cpu: 512m


### PR DESCRIPTION
Deployment annotations are needed in some environments. This change should allow that. By default, there will be no new annotations.