### PR TITLE
add SERVICE__DATABASE_URL to api.tf deployment

### DIFF
--- a/azure_kubernetes_service/api.tf
+++ b/azure_kubernetes_service/api.tf
@@ -60,6 +60,10 @@ resource "kubernetes_deployment" "api" {
             value = local.postgres_host
           }
           env {
+            name  = "SERVICES__DATABASE_URL"
+            value = local.postgres_url
+          }
+          env {
             name  = "SERVICES__REDIS_URL"
             value = local.redis_url
           }


### PR DESCRIPTION
Hello all, 

Should this environment variable be set for the API container deployment? It is set for the other containers. In our case, we needed to add this, as otherwise Django appears to default to a hostname of `postgres`, which doesn't resolve in our case

Please let me know 

Thanks