### PR TITLE
Fix typo in helm template for SCM CA Cert

### DIFF
--- a/helm/codecov-enterprise/templates/scm-ca-cert-secret.yaml
+++ b/helm/codecov-enterprise/templates/scm-ca-cert-secret.yaml
@@ -7,8 +7,8 @@ metadata:
     {{ $key }}: {{ $val | quote }}
   {{- end }}
 data:
-  {{ if .Values.scm_ca_cert }}
-  scm_ca_cert.pem: {{ .Values.scm_ca_cert | b64enc | quote }}
+  {{ if .Values.scmCaCert }}
+  scm_ca_cert.pem: {{ .Values.scmCaCert | b64enc | quote }}
   {{ else }}
   scm_ca_cert.pem: ""
   {{ end }}


### PR DESCRIPTION
helm/values.yaml specifies the variable 'scmCaCert' for the private
key file used by an SCM such as Github Enterprise, but in the helm
template 'scm-ca-cert-secret.yaml' instead of 'scmCaCert', the value
'scm_ca_cert' was incorrectly specified. I have replaced this with
the correct 'scmCaCert' from helm/values.yaml